### PR TITLE
Fix a race condition in a test case

### DIFF
--- a/tests/testthat/test-fish.R
+++ b/tests/testthat/test-fish.R
@@ -15,6 +15,8 @@ test_that("engine works", {
 
   # Stop engine
   engine$quit()
+  # It might take a sec to quit
+  engine$process$wait(3000)
   expect_false(engine$process$is_alive())
   expect_error(engine$process$get_status())
 


### PR DESCRIPTION
After calling engine$quit() we need to wait for the process
to actually end, before calling process$is_alive(). If R is
too fast, then the process has no time to quit.

Partially addresses #4.