### PR TITLE
Work around the "not imported from" check

### DIFF
--- a/R/fish.R
+++ b/R/fish.R
@@ -494,3 +494,10 @@ fish_find <- function() {
 
   return(file)
 }
+
+# Work around R CMD check issue:
+# Namespaces in Imports field not imported from
+workaround <- function() {
+  processx::process
+  R6::R6Class
+}


### PR DESCRIPTION
R CMD check makes sure that every package that
is listed in Imports is used in the code. Currently
the package only uses R6 and processx at install time,
and the check misses that and gives:

```
* checking dependencies in R code ... NOTE
Namespaces in Imports field not imported from:
  ‘R6’ ‘processx’
    All declared Imports should be used.
```

An easy fix is to create a dummy function that refers
to both packages.