### PR TITLE
Put the finalizer into tryCatch()

### DIFF
--- a/R/fish.R
+++ b/R/fish.R
@@ -467,7 +467,10 @@ fish <- R6::R6Class(
 
     # @description Kill engine when object is collected
     finalize = function() {
-      self$run("quit")
+      tryCatch(
+        self$run("quit"),
+        error = function(err) { }
+      )
     }
   )
 )


### PR DESCRIPTION
Because if the process is not running, e.g. because we
called `$quit()` explicitly, then the methods of the process
object will fail.

This and #5 together close #4.